### PR TITLE
Allow Article field to allow_twig: true

### DIFF
--- a/src/Entity/ArticleField.php
+++ b/src/Entity/ArticleField.php
@@ -22,7 +22,7 @@ class ArticleField extends Field implements Excerptable, FieldInterface
      */
     public function getTwigValue()
     {
-        $value = $this->getParsedValue();
+        $value = parent::getTwigValue();
 
         return new Markup($value, 'UTF-8');
     }


### PR DESCRIPTION
Fixes #4 

When `allow_twig` is set to `true` the Article field will allow to use Twig syntax in the editor.