### PR TITLE
Replace deprecated DOMNodeInserted listener with MutationObserver

### DIFF
--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -23,11 +23,6 @@ function initArticles() {
     ArticleEditor('.article-field', {{ article_settings() }});
 }
 
-    const config = {
-        childList: true,
-        subtree:   true
-    };
-
     const articleObserver = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
             if (mutation.type === 'childList' && mutation.addedNodes.length) {

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -2,33 +2,52 @@
 <link rel="stylesheet" href="{{ asset('assets/article/css/article-editor.min.css', 'public') }}">
 {{ article_includes() }}
 <script>
-ArticleEditor.settings = {
-    callbacks: {
-        image: {
-            uploadError: function(response)
-            {
-                alert(response.message);
-            }
-        },
-        file: {
-            uploadError: function(response)
-            {
-                alert(response.message);
+    ArticleEditor.settings = {
+        callbacks: {
+            image: {
+                uploadError: function(response) {
+                    alert(response.message);
+                }
+            },
+            file: {
+                uploadError: function(response) {
+                    alert(response.message);
+                }
             }
         }
+    };
+
+    function initArticles() {
+        ArticleEditor('.article-field', {{ article_settings() }});
     }
-};
 
-function initArticles() {
-    ArticleEditor('.article-field', {{ article_settings() }});
-}
+    const config = {
+        childList: true,
+        subtree:   true
+    };
 
-$(document).on('DOMNodeInserted', function(e) {
-    if ( $(e.target).hasClass('collection-item') ) {
-        initArticles();
-    }
-});
+    const articleObserver = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.type === 'childList' && mutation.addedNodes.length) {
+                for (let node of mutation.addedNodes) {
+                    if (
+                        node.nodeType === Node.ELEMENT_NODE &&
+                        node.classList.contains('collection-item')
+                    ) {
+                        initArticles();
+                        return;
+                    }
+                    if (node.querySelector && node.querySelector('.collection-item')) {
+                        initArticles();
+                        return;
+                    }
+                }
+            }
+        });
+    });
 
-initArticles();
+    articleObserver.observe(document.body, config);
+
+    document.addEventListener('DOMContentLoaded', initArticles);
 
 </script>

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -23,28 +23,20 @@ function initArticles() {
     ArticleEditor('.article-field', {{ article_settings() }});
 }
 
-    const articleObserver = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-            if (mutation.type === 'childList' && mutation.addedNodes.length) {
-                for (let node of mutation.addedNodes) {
-                    if (
-                        node.nodeType === Node.ELEMENT_NODE &&
-                        node.classList.contains('collection-item')
-                    ) {
-                        initArticles();
-                        return;
-                    }
-                    if (node.querySelector && node.querySelector('.collection-item')) {
-                        initArticles();
-                        return;
-                    }
-                }
+const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+        mutation.addedNodes.forEach(function(node) {
+            if ($(node).hasClass('collection-item')) {
+                initArticles();
             }
         });
     });
+});
 
-    articleObserver.observe(document.body, config);
+observer.observe(document.body, {
+    childList: true,
+    subtree: true
+});
 
-    document.addEventListener('DOMContentLoaded', initArticles);
-
+initArticles();
 </script>

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -2,24 +2,26 @@
 <link rel="stylesheet" href="{{ asset('assets/article/css/article-editor.min.css', 'public') }}">
 {{ article_includes() }}
 <script>
-    ArticleEditor.settings = {
-        callbacks: {
-            image: {
-                uploadError: function(response) {
-                    alert(response.message);
-                }
-            },
-            file: {
-                uploadError: function(response) {
-                    alert(response.message);
-                }
+ArticleEditor.settings = {
+    callbacks: {
+        image: {
+            uploadError: function(response)
+            {
+                alert(response.message);
+            }
+        },
+        file: {
+            uploadError: function(response)
+            {
+                alert(response.message);
             }
         }
-    };
-
-    function initArticles() {
-        ArticleEditor('.article-field', {{ article_settings() }});
     }
+};
+
+function initArticles() {
+    ArticleEditor('.article-field', {{ article_settings() }});
+}
 
     const config = {
         childList: true,

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -24,7 +24,7 @@ function initArticles() {
 }
 
 const observerArticle = new MutationObserver(function(mutations) {
-    mutations.forEach(function(mutation) {
+    for (let mutation of mutations) {
         if (mutation.type === 'childList' && mutation.addedNodes.length) {
             mutation.addedNodes.forEach(function(node) {
                 if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('collection-item')) {

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -26,7 +26,7 @@ function initArticles() {
 const observerArticle = new MutationObserver(function(mutations) {
     for (let mutation of mutations) {
         if (mutation.type === 'childList' && mutation.addedNodes.length) {
-            mutation.addedNodes.forEach(function(node) {
+            for (let node of mutation.addedNodes) {
                 if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('collection-item')) {
                     initArticles();
                 }

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -23,7 +23,7 @@ function initArticles() {
     ArticleEditor('.article-field', {{ article_settings() }});
 }
 
-const observer = new MutationObserver(function(mutations) {
+const observerArticle = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
         mutation.addedNodes.forEach(function(node) {
             if ($(node).hasClass('collection-item')) {
@@ -33,7 +33,7 @@ const observer = new MutationObserver(function(mutations) {
     });
 });
 
-observer.observe(document.body, {
+observerArticle.observe(document.body, {
     childList: true,
     subtree: true
 });

--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -25,11 +25,13 @@ function initArticles() {
 
 const observerArticle = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {
-        mutation.addedNodes.forEach(function(node) {
-            if ($(node).hasClass('collection-item')) {
-                initArticles();
-            }
-        });
+        if (mutation.type === 'childList' && mutation.addedNodes.length) {
+            mutation.addedNodes.forEach(function(node) {
+                if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('collection-item')) {
+                    initArticles();
+                }
+            });
+        }
     });
 });
 


### PR DESCRIPTION
Replace deprecated DOMNodeInserted listener with MutationObserver
- Resolve Chrome incompatibility when adding collection items or other dynamic nodes  
- Restore cross-browser support (Chrome, Mozilla, etc.)  
- Future-proof DOM mutation handling